### PR TITLE
feat: pin dependencies

### DIFF
--- a/default.json
+++ b/default.json
@@ -8,6 +8,7 @@
         ":rebaseStalePrs",
         "replacements:all"
     ],
+    "rangeStrategy": "pin",
     "semanticCommits": true,
     "major": {
         "automergeType": "pr"


### PR DESCRIPTION
Väldigt dålig på Renovate, men jag tänker att vi alltid vill pinna beroenden, eller?

Jag ser att det just nu är lite blandat i våra repos på github, osäker på varför men tänker att denna flaggan skall forcera att de alltid är pinnade.

https://docs.renovatebot.com/configuration-options/#rangestrategy